### PR TITLE
Fix #72 XMLEventReader does not handle &apos; properly

### DIFF
--- a/src/main/scala/scala/xml/Utility.scala
+++ b/src/main/scala/scala/xml/Utility.scala
@@ -97,13 +97,11 @@ object Utility extends AnyRef with parsing.TokenTests {
       "lt" -> '<',
       "gt" -> '>',
       "amp" -> '&',
-      "quot" -> '"'
-    // enigmatic comment explaining why this isn't escaped --
-    // is valid xhtml but not html, and IE doesn't know it, says jweb
-    // "apos"  -> '\''
+      "quot" -> '"',
+      "apos"  -> '\''
     )
     val escMap = pairs map { case (s, c) => c -> ("&%s;" format s) }
-    val unescMap = pairs ++ Map("apos" -> '\'')
+    val unescMap = pairs
   }
   import Escapes.{ escMap, unescMap }
 

--- a/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
+++ b/src/test/scala/scala/xml/pull/XMLEventReaderTest.scala
@@ -58,4 +58,30 @@ class XMLEventReaderTest {
    while(er.hasNext) er.next()
    er.stop()
  }
+
+  @Test
+  def entityRefTest: Unit = { // SI-7796
+    val source = Source.fromString("<text>&quot;&apos;&lt;&gt;&amp;</text>")
+    val er = new XMLEventReader(source)
+
+    assertTrue(er.next match {
+      case EvElemStart(_, "text", _, _) => true
+      case _ => false
+    })
+
+    val entities = Seq(
+      EvEntityRef("quot"),
+      EvEntityRef("apos"),
+      EvEntityRef("lt"),
+      EvEntityRef("gt"),
+      EvEntityRef("amp"))
+
+    assertEquals(entities, er.take(entities.size).toSeq)
+
+    assertTrue(er.next match {
+      case EvElemEnd(_, "text") => true
+      case _ => false
+    })
+    assertTrue(er.isEmpty)
+  }
 }


### PR DESCRIPTION
```
* src/main/scala/scala/xml/Utility.scala: Uncomment apos in
Escapes map.

* src/test/scala/scala/xml/pull/XMLEventReaderTest.scala (entityRefTest):
Unit test from Fehmi Can Saglam <fehmican.saglam@gmail.com>
```
