### PR TITLE
Always build the Scala 2.11.7 compatible version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions         := {
   if (java.startsWith("1.6.") || java.startsWith("1.7."))
     Seq("2.11.7", "2.12.0-M1")
   else if (java.startsWith("1.8.") || java.startsWith("1.9."))
-    Seq("2.12.0-M2")
+    Seq("2.11.7", "2.12.0-M2")
   else
     sys.error(s"don't know what Scala versions to build on $java")
 }


### PR DESCRIPTION
We're using the latest stable versions, ie. Java 1.8 and Scala 2.11.7. This fix is needed to use this fork of scala-xml as a project dependency.
